### PR TITLE
RSpec Cleanup

### DIFF
--- a/spec/eng_bootcamp_2020_stephan_spec.rb
+++ b/spec/eng_bootcamp_2020_stephan_spec.rb
@@ -55,13 +55,26 @@ RSpec.describe EngBootcamp2020Stephan do
   describe '.hello_gusto_with_configured_env' do
     subject { described_class.hello_gusto_with_configured_env }
 
-    it 'can output hello gusto when no env is configured' do
-      expect(subject).to eq('hello gusto')
+    let(:configured_env) { nil }
+
+    around(:each) do |example|
+      previous_env = EngBootcamp2020Stephan.instance_variable_get(:@env)
+      EngBootcamp2020Stephan.env = configured_env
+      EngBootcamp2020Stephan.env = previous_env
     end
 
-    it 'can output hello gusto with configured env' do
-      EngBootcamp2020Stephan.env = 'CONFIGURED TEST'
-      expect(subject).to eq('hello gusto - ENV CONFIGURED TEST')
+    context 'when no env is configured' do
+      it 'can output hello gusto when no env is configured' do
+        expect(subject).to eq('hello gusto')
+      end
+    end
+
+    context 'when an env is configured' do
+      let(:configured_env) { 'CONFIGURED TEST' }
+
+      it 'can output hello gusto with configured env' do
+        expect(subject).to eq('hello gusto - ENV CONFIGURED TEST')
+      end
     end
   end
 end

--- a/spec/eng_bootcamp_2020_stephan_spec.rb
+++ b/spec/eng_bootcamp_2020_stephan_spec.rb
@@ -8,8 +8,10 @@ RSpec.describe EngBootcamp2020Stephan do
   end
 
   describe '.hello_gusto' do
+    subject { described_class.hello_gusto }
+
     it 'can output hello gusto' do
-      expect(EngBootcamp2020Stephan.hello_gusto).to eq('hello gusto')
+      expect(subject).to eq('hello gusto')
     end
 
     it 'outputs hello gusto when loaded' do
@@ -19,36 +21,47 @@ RSpec.describe EngBootcamp2020Stephan do
   end
 
   describe '.hello_gusto_with_env_param' do
+    let(:env_param) { 'MY_ENV' }
+    subject { described_class.hello_gusto_with_env_param(env_param) }
+
     it 'can output hello gusto' do
-      expect(EngBootcamp2020Stephan.hello_gusto_with_env_param('MY_ENV')).to eq('hello gusto - ENV MY_ENV')
+      expect(subject).to eq('hello gusto - ENV MY_ENV')
     end
   end
 
   describe '.hello_gusto_with_rails_env' do
-    it 'can output hello gusto when there is no Rails env' do
-      expect(EngBootcamp2020Stephan.hello_gusto_with_rails_env).to eq('hello gusto')
+    subject { described_class.hello_gusto_with_rails_env }
+
+    context 'when Rails is not defined' do
+      it 'can output hello gusto when there is no Rails env' do
+        expect(subject).to eq('hello gusto')
+      end
     end
 
-    it 'can output hello gusto with Rails env' do
-      Rails = double()
-      allow(Rails).to receive(:env).and_return :TEST
+    context 'when Rails is defined' do
+      let(:rails_env) { :TEST }
 
-      expect(EngBootcamp2020Stephan.hello_gusto_with_rails_env).to eq('hello gusto - ENV TEST')
+      before do
+        Rails = double()
+        allow(Rails).to receive(:env).and_return rails_env
+      end
+
+      it 'can output hello gusto with Rails env' do
+        expect(subject).to eq('hello gusto - ENV TEST')
+      end
     end
   end
 
   describe '.hello_gusto_with_configured_env' do
-    before do
-      EngBootcamp2020Stephan.env = nil
-    end
+    subject { described_class.hello_gusto_with_configured_env }
 
     it 'can output hello gusto when no env is configured' do
-      expect(EngBootcamp2020Stephan.hello_gusto_with_configured_env).to eq('hello gusto')
+      expect(subject).to eq('hello gusto')
     end
 
     it 'can output hello gusto with configured env' do
       EngBootcamp2020Stephan.env = 'CONFIGURED TEST'
-      expect(EngBootcamp2020Stephan.hello_gusto_with_configured_env).to eq('hello gusto - ENV CONFIGURED TEST')
+      expect(subject).to eq('hello gusto - ENV CONFIGURED TEST')
     end
   end
 end


### PR DESCRIPTION
This makes two small changes to the test suite without changing anything in the gem's `lib/`:

1. Defines one `subject` for each `describe`, making it clear what is being tested in each example, and allowing easier refactor if the subject's method name (eg) needs to change
2. Prevents a singleton value from leaking across tests by changing it in an `around` block, and then changing it back to whatever value it was before